### PR TITLE
EA-2224: Remove credentials header from CORS responses

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,7 @@
 **/.settings/
 **.classpath
 **.log
+
+#IntelliJ project files
+.idea
+*.iml

--- a/entity-web/src/main/resources/entity-web-mvc.xml
+++ b/entity-web/src/main/resources/entity-web-mvc.xml
@@ -60,14 +60,14 @@
 	<mvc:cors>
 		<mvc:mapping path="/api-docs" allowed-origins="*" exposed-headers="Access-Control-Allow-Origin"/>
 		<mvc:mapping path="/api-docs/**" allowed-origins="*" exposed-headers="Access-Control-Allow-Origin"/>
-		<mvc:mapping path="/entity/resolve" allowed-origins="*" allowed-methods="GET" exposed-headers="Location,Allow" max-age="600" allow-credentials="true"/>
-		<mvc:mapping path="/entity/suggest" allowed-origins="*" allowed-methods="GET" exposed-headers="Allow" max-age="600" allow-credentials="true"/>
-		<mvc:mapping path="/entity/search" allowed-origins="*" allowed-methods="GET" exposed-headers="Allow" max-age="600" allow-credentials="true"/>
-		<mvc:mapping path="/entity/*/*/*" allowed-origins="*" allowed-methods="GET" allowed-headers="If-Match" exposed-headers="Allow, Vary,Link,ETag" max-age="600" allow-credentials="true"/>
+		<mvc:mapping path="/entity/resolve" allowed-origins="*" allowed-methods="GET" exposed-headers="Location,Allow" max-age="600" allow-credentials="false"/>
+		<mvc:mapping path="/entity/suggest" allowed-origins="*" allowed-methods="GET" exposed-headers="Allow" max-age="600" allow-credentials="false"/>
+		<mvc:mapping path="/entity/search" allowed-origins="*" allowed-methods="GET" exposed-headers="Allow" max-age="600" allow-credentials="false"/>
+		<mvc:mapping path="/entity/**" allowed-origins="*" allowed-methods="GET" allowed-headers="If-Match" exposed-headers="Allow, Vary,Link,ETag" max-age="600" allow-credentials="false"/>
 		<mvc:mapping path="/scheme/" allowed-origins="*" allowed-methods="POST" 
-			exposed-headers="Allow, Link, ETag, Preference-Applied, Cache-Control" max-age="600"  allow-credentials="true"/>
+			exposed-headers="Allow, Link, ETag, Preference-Applied, Cache-Control" max-age="600"  allow-credentials="false"/>
 		<mvc:mapping path="/scheme/**" allowed-origins="*" allowed-methods="GET, PUT, DELETE, HEAD, OPTIONS" 
-			exposed-headers="Allow, Vary, Link, ETag, Preference-Applied" max-age="600" allow-credentials="true"/>
+			exposed-headers="Allow, Vary, Link, ETag, Preference-Applied" max-age="600" allow-credentials="false"/>
 	</mvc:cors>
 
 	<bean class="eu.europeana.api.common.config.swagger.SwaggerConfig">


### PR DESCRIPTION
- this enables the Access-Control-Allow-Origin:* header